### PR TITLE
Fix: GameStartManagerUpdatePatch postfix null error

### DIFF
--- a/src/CrowdedMod/Patches/GenericPatches.cs
+++ b/src/CrowdedMod/Patches/GenericPatches.cs
@@ -63,7 +63,7 @@ internal static class GenericPatches
     [HarmonyPatch(typeof(GameStartManager), nameof(GameStartManager.Update))]
     public static class GameStartManagerUpdatePatch
     {
-        private static string? fixDummyCounterColor;
+        private static string fixDummyCounterColor = string.Empty;
         public static void Prefix(GameStartManager __instance)
         {
             if (GameData.Instance == null || __instance.LastPlayerCount == GameData.Instance.PlayerCount)
@@ -87,13 +87,16 @@ internal static class GenericPatches
 
         public static void Postfix(GameStartManager __instance)
         {
-            if (fixDummyCounterColor == null)
+            if (GameData.Instance == null ||
+                GameManager.Instance == null ||
+                GameManager.Instance.LogicOptions == null ||
+                string.IsNullOrEmpty(fixDummyCounterColor))
             {
                 return;
             }
 
             __instance.PlayerCounter.text = $"{fixDummyCounterColor}{GameData.Instance.PlayerCount}/{GameManager.Instance.LogicOptions.MaxPlayers}";
-            fixDummyCounterColor = null;
+            fixDummyCounterColor = string.Empty;
         }
     }
 
@@ -138,7 +141,7 @@ internal static class GenericPatches
     //             {
     //                 Debug.LogError("[CM] InnerNetServer::HandleNewGameJoin MessageWriter 2 Exception: " +
     //                                exception.Message);
-    //                 // ama too stupid for this 
+    //                 // ama too stupid for this
     //                 // Debug.LogException(exception.InnerException, __instance);
     //             }
     //             finally


### PR DESCRIPTION
GameStartManager Prefix checks GameData.Instance for null, but the null check is not performed in Postfix, and if it slipped through for some reason, a null error would occur.

Also, the code has been changed to be more secure by making the assignment to a string an empty string instead of null.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved null safety and error handling in game state management
	- Enhanced robustness of color settings and game option checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->