### PR TITLE
fix: performance

### DIFF
--- a/src/CrowdedMod/Components/MeetingHudPagingBehaviour.cs
+++ b/src/CrowdedMod/Components/MeetingHudPagingBehaviour.cs
@@ -18,7 +18,19 @@ public class MeetingHudPagingBehaviour : AbstractPagingBehaviour
 
     [HideFromIl2Cpp]
     public IEnumerable<PlayerVoteArea> Targets => meetingHud.playerStates.OrderBy(p => p.AmDead);
-    public override int MaxPageIndex => (Targets.Count() - 1) / MaxPerPage;
+    public override int MaxPageIndex
+    {
+        get
+        {
+            if (maxPageIndex == -1)
+            {
+                maxPageIndex = (Targets.Count() - 1) / MaxPerPage;
+            }
+            return maxPageIndex;
+        }
+    }
+
+    private int maxPageIndex = -1;
 
     public override void Start() => OnPageChanged();
 


### PR DESCRIPTION
Calculate `MaxPageIndex` in `MeetingHudPagingBehaviour` only once to avoid extra calculations.
Since the number of players is determined at the beginning of the game, this process should be fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the paging mechanism by caching the computed maximum page index on first use, resulting in more efficient paging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->