### PR TITLE
feat:remove default official server logics

### DIFF
--- a/src/CrowdedMod/CrowdedModPlugin.cs
+++ b/src/CrowdedMod/CrowdedModPlugin.cs
@@ -27,5 +27,29 @@ public partial class CrowdedModPlugin : BasePlugin
         NormalGameOptionsV08.MinPlayers = Enumerable.Repeat(4, 127).ToArray();
 
         Harmony.PatchAll();
+
+        RemoveVanillaServer();
     }
+
+    public static void RemoveVanillaServer()
+    {
+        var sm = ServerManager.Instance;
+        var curRegions = sm.AvailableRegions;
+        sm.AvailableRegions = curRegions.Where(region => !IsVanillaServer(region)).ToArray();
+
+        var defaultRegion = ServerManager.DefaultRegions;
+        ServerManager.DefaultRegions = defaultRegion.Where(region => !IsVanillaServer(region)).ToArray();
+
+        if (IsVanillaServer(sm.CurrentRegion))
+        {
+            var region = defaultRegion.FirstOrDefault();
+            sm.SetRegion(region);
+        }
+    }
+
+    private static bool IsVanillaServer(IRegionInfo regionInfo)
+        => regionInfo.TranslateName is
+            StringNames.ServerAS or
+            StringNames.ServerEU or
+            StringNames.ServerNA;
 }

--- a/src/CrowdedMod/Patches/GenericPatches.cs
+++ b/src/CrowdedMod/Patches/GenericPatches.cs
@@ -106,6 +106,15 @@ internal static class GenericPatches
         }
     }
 
+    [HarmonyPatch(typeof(MainMenuManager), nameof(MainMenuManager.Start))]
+    public static class RemoveVanillaServerPatch
+    {
+        public static void Postfix()
+        {
+            CrowdedModPlugin.RemoveVanillaServer();
+        }
+    }
+
     // Will be patched with signatures later when BepInEx reveals it
     // [HarmonyPatch(typeof(InnerNetServer), nameof(InnerNetServer.HandleNewGameJoin))]
     // public static class InnerNetSerer_HandleNewGameJoin
@@ -138,7 +147,7 @@ internal static class GenericPatches
     //             {
     //                 Debug.LogError("[CM] InnerNetServer::HandleNewGameJoin MessageWriter 2 Exception: " +
     //                                exception.Message);
-    //                 // ama too stupid for this 
+    //                 // ama too stupid for this
     //                 // Debug.LogException(exception.InnerException, __instance);
     //             }
     //             finally


### PR DESCRIPTION
Add logic to delete official servers on the mod side
To prevent any trouble from connecting to the official servers of AmongUs with this mod installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced server selection by excluding vanilla servers from available options.
  - Automatically updates the default region when a vanilla server is detected.
  - Integrates server filtering during the application’s startup for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->